### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/src/pyll/__init__.py
+++ b/src/pyll/__init__.py
@@ -1,2 +1,2 @@
 __version__ = '0.9'
-__url__ = 'http://pyll.readthedocs.org/'
+__url__ = 'https://pyll.readthedocs.io/'


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
